### PR TITLE
Feature/1 hide posts instead of removing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.vscode/settings.json

--- a/content.js
+++ b/content.js
@@ -68,7 +68,7 @@ const hideUserPosts = {
                     .offsetWidth;
                 const userName = post.querySelector('.pa-author a').textContent;
 
-                const spoilerContent = `<div style="width:${postHeadingWidth}px;" class="hvHiddenSpoiler">Посты ${userName} скрыты. <button class="button" type="button"><strong>Посмотреть пост</strong></button></div>`;
+                const spoilerContent = `<div style="width:${postHeadingWidth}px;" class="quote-box spoiler-box hvHiddenSpoiler">Посты ${userName} скрыты. <button class="button" type="button"><strong>Посмотреть пост</strong></button></div>`;
 
                 postContainer.insertAdjacentHTML('beforebegin', spoilerContent);
 

--- a/content.js
+++ b/content.js
@@ -1,7 +1,7 @@
 const hideUserPosts = {
     init: function() {
         const pun = document.getElementById('pun');
-        if (! pun) return;
+        if (!pun) return;
 
         this.isGuest = pun.classList.contains('isguest');
         this.posts = document.querySelectorAll('.post') || [];
@@ -9,7 +9,9 @@ const hideUserPosts = {
 
         const crumbs = document.getElementById('pun-crumbs1');
         const forumLinks = crumbs.querySelectorAll('a');
-        this.forumName = forumLinks[forumLinks.length - 1].text.toLocaleLowerCase();
+        this.forumName = forumLinks[
+            forumLinks.length - 1
+        ].text.toLocaleLowerCase();
 
         this.updateContextMenu = this.updateContextMenu.bind(this);
 
@@ -18,16 +20,25 @@ const hideUserPosts = {
     },
 
     getHideInfo: async function() {
-        chrome.runtime.sendMessage({
-            type: 'getForumInfo',
-            hostname: location.hostname,
-            forumName: this.forumName
-        }, result => {
-            this.hidePosts(result);
+        let hideInsteadOfRemoving = false;
+
+        await chrome.storage.sync.get(['hvHU_hideInstead'], items => {
+            hideInsteadOfRemoving = items.hvHU_hideInstead;
         });
+
+        chrome.runtime.sendMessage(
+            {
+                type: 'getForumInfo',
+                hostname: location.hostname,
+                forumName: this.forumName
+            },
+            result => {
+                this.hidePosts(result, hideInsteadOfRemoving);
+            }
+        );
     },
 
-    hidePosts: function(data) {
+    hidePosts: function(data, hideInsteadOfRemoving) {
         if (Object.keys(data) === 0) return;
 
         this.posts.forEach(post => {
@@ -35,15 +46,101 @@ const hideUserPosts = {
 
             const id = this.getUserId(post);
             if (id && Object.keys(data).includes(id)) {
-                post.classList.toggle('hvHiddenPost', data[id].hidden);
+                post.classList.toggle(
+                    hideInsteadOfRemoving ? 'hvHiddenPost' : 'hvRemovedPost',
+                    data[id].hidden
+                );
+
+                if (hideInsteadOfRemoving) {
+                    this.configurePostSpoiler(post);
+                }
             }
-        })
+        });
+    },
+
+    configurePostSpoiler: function(post) {
+        const spoiler = post.querySelector('.hvHiddenSpoiler');
+
+        if (post.classList.contains('hvHiddenPost')) {
+            if (!spoiler) {
+                const postContainer = post.querySelector('.container');
+                const postHeadingWidth = post.querySelector('h3 span')
+                    .offsetWidth;
+                const userName = post.querySelector('.pa-author a').textContent;
+
+                const spoilerContent = `<div style="width:${postHeadingWidth}px;" class="hvHiddenSpoiler">Посты ${userName} в этом подфоруме скрыты. <button class="button" type="button"><strong>Посмотреть пост</strong></button></div>`;
+
+                postContainer.insertAdjacentHTML('beforebegin', spoilerContent);
+
+                this.hidePostUnderSpoiler(post);
+            }
+            return;
+        }
+
+        if (spoiler) {
+            spoiler.remove();
+        }
+    },
+
+    hidePostUnderSpoiler: function(post) {
+        if (post.classList.contains('hvShow')) {
+            post.classList.remove('hvShow');
+        }
+
+        const showButton = post.querySelector('.hvHiddenSpoiler button');
+
+        if (showButton) {
+            showButton.innerHTML = `<strong>Посмотреть пост</strong>`;
+
+            const showPostUnderSpoiler = this.showPostUnderSpoiler.bind(this);
+
+            showButton.addEventListener(
+                'click',
+                function _showPostListener() {
+                    showPostUnderSpoiler(post);
+                    showButton.removeEventListener(
+                        _showPostListener,
+                        () => {},
+                        true
+                    );
+                },
+                true
+            );
+        }
+    },
+
+    showPostUnderSpoiler: function(post) {
+        if (!post.classList.contains('hvShow')) {
+            post.classList.add('hvShow');
+        }
+
+        const spoiler = post.querySelector('.hvHiddenSpoiler');
+        const hideButton = post.querySelector('.hvHiddenSpoiler button');
+
+        if (hideButton) {
+            hideButton.innerHTML = `<strong>Скрыть пост снова</strong>`;
+
+            const hidePostUnderSpoiler = this.hidePostUnderSpoiler.bind(this);
+
+            hideButton.addEventListener(
+                'click',
+                function _hidePostListener() {
+                    hidePostUnderSpoiler(post);
+                    hideButton.removeEventListener(
+                        _hidePostListener,
+                        () => {},
+                        true
+                    );
+                },
+                true
+            );
+        }
     },
 
     addListeners: function() {
         document.addEventListener('contextmenu', this.updateContextMenu);
 
-        chrome.runtime.onMessage.addListener((request) => {
+        chrome.runtime.onMessage.addListener(request => {
             if (request.type === 'updateHiddenUsers') {
                 this.getHideInfo();
             }
@@ -53,14 +150,14 @@ const hideUserPosts = {
     updateContextMenu: function(event) {
         const target = event.target;
 
-        if (! target.closest('.pa-author')) {
+        if (!target.closest('.pa-author')) {
             chrome.runtime.sendMessage({
                 type: 'updateContextMenu',
                 forumName: this.forumName,
                 hostname: location.hostname
             });
             return;
-        };
+        }
 
         const post = target.closest('.post');
 
@@ -76,21 +173,22 @@ const hideUserPosts = {
                 userName: event.target.text,
                 userId
             }
-        })
+        });
     },
 
     getUserId: function(post) {
         const profileMenuItem = this.isGuest
-                ? post.querySelector('.pa-author')
-                : post.querySelector('.pl-email');
+            ? post.querySelector('.pa-author')
+            : post.querySelector('.pl-email');
 
         if (!profileMenuItem) return null;
 
         const profileLink = profileMenuItem.querySelector('a');
-        if (! profileLink.href || /javascript\:/.test(profileLink.href)) return null;
+        if (!profileLink.href || /javascript\:/.test(profileLink.href))
+            return null;
 
         return profileLink.href.match(/(\d+)$/)[0];
     }
-}
+};
 
 hideUserPosts.init();

--- a/content.js
+++ b/content.js
@@ -68,7 +68,7 @@ const hideUserPosts = {
                     .offsetWidth;
                 const userName = post.querySelector('.pa-author a').textContent;
 
-                const spoilerContent = `<div style="width:${postHeadingWidth}px;" class="hvHiddenSpoiler">Посты ${userName} в этом подфоруме скрыты. <button class="button" type="button"><strong>Посмотреть пост</strong></button></div>`;
+                const spoilerContent = `<div style="width:${postHeadingWidth}px;" class="hvHiddenSpoiler">Посты ${userName} скрыты. <button class="button" type="button"><strong>Посмотреть пост</strong></button></div>`;
 
                 postContainer.insertAdjacentHTML('beforebegin', spoilerContent);
 

--- a/manifest.json
+++ b/manifest.json
@@ -7,16 +7,16 @@
     },
     "permissions": ["activeTab", "storage", "contextMenus"],
     "background": {
-      "scripts": ["background.js"],
-      "persistent": false
+        "scripts": ["background.js"],
+        "persistent": false
     },
     "content_scripts": [
-      {
-        "matches": [ "*://*/*" ],
-        "run_at": "document_idle",
-        "js": [ "content.js" ],
-        "css": [ "style.css" ]
-      }
+        {
+            "matches": ["*://*/*"],
+            "run_at": "document_idle",
+            "js": ["content.js"],
+            "css": ["style.css"]
+        }
     ],
     "browser_action": {
         "default_title": "Игнор спасет мир",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "Игнор спасет мир",
-    "version": "1.0",
+    "version": "1.1.0",
     "icons": {
         "128": "./icons/icon_128.png"
     },

--- a/popup.html
+++ b/popup.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="ru">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -11,12 +12,14 @@
             font-family: Helvetica, Arial, sans-serif;
             color: #333;
         }
+
         input[type=radio] {
             opacity: 0;
             visibility: hidden;
             position: absolute;
         }
-        label {
+
+        .hvHU_docs__label {
             display: block;
             font-weight: bold;
             font-size: 12px;
@@ -25,12 +28,15 @@
             cursor: pointer;
             text-transform: uppercase;
         }
-        input[type=radio]:checked + label {
+
+        input[type=radio]:checked+label {
             background: #eee;
         }
-        input[type=radio]:checked + label + .info {
+
+        input[type=radio]:checked+label+.info {
             max-height: 1000px;
         }
+
         .info {
             max-height: 0;
             overflow: hidden;
@@ -40,33 +46,71 @@
             border-style: solid;
             box-sizing: border-box;
         }
+
         .info p {
             padding: 8px;
             margin: 0;
         }
+
+        .hvHU_options {
+            padding: 8px 16px;
+            border: solid 1px #999;
+            font-family: Helvetica, Arial, sans-serif;
+            color: #333;
+        }
+
+        .hvHU_options__option {
+            display: block;
+            margin-bottom: 8px;
+        }
+
+        h2 {
+            display: block;
+            font-weight: bold;
+            font-size: 12px;
+            padding-bottom: 8px;
+            margin: 0;
+            text-transform: uppercase;
+        }
     </style>
 </head>
+
 <body>
+    <div class="hvHU_options">
+        <h2>Дополнительные настройки:</h2>
+        <form>
+            <label class="hvHU_options__option" for="hide_instead">
+                <input type="checkbox" id="hide_instead"> Прятать посты юзера, а не вырезать их
+            </label>
+        </form>
+    </div>
     <div class="hvHU_docs">
-        <input type="radio" name="hvHUdocs" id="block_user"><label for="block_user">Бросить юзера в игнор</label>
+        <input type="radio" name="hvHUdocs" id="block_user"><label class="hvHU_docs__label" for="block_user">Бросить
+            юзера в игнор</label>
         <div class="info">
             <p>Вызвать контекстное меню на нике пользователя. Если в меню нет нужного пункта, повторить.</p>
         </div>
-        <input type="radio" name="hvHUdocs" id="show_user"><label for="show_user">Вытащить из игнора</label>
+        <input type="radio" name="hvHUdocs" id="show_user"><label class="hvHU_docs__label" for="show_user">Вытащить из
+            игнора</label>
         <div class="info">
-            <p>Вызвать контекстное меню в любом месте страницы и выбрать амнистированного в подменю “Игнор спасёт мир”.</p>
+            <p>Вызвать контекстное меню в любом месте страницы и выбрать амнистированного в подменю “Игнор спасёт мир”.
+            </p>
         </div>
-        <input type="radio" name="hvHUdocs" id="faq"><label for="faq">FAQ</label>
+        <input type="radio" name="hvHUdocs" id="faq"><label class="hvHU_docs__label" for="faq">FAQ</label>
         <div class="info">
             <p><b>1. На маске сработает? </b><br>
-            Сработает, но ник в меню запомнит не реальный, а тот, что был на маске.<br>
-            <b>2. Вконтакте работать будет?</b><br>
-            Нет, только на платформах типа mybb.<br>
-            <b>3. Юзер не узнает?</b><br>
-            Разве что расскажешь ему сам(а).<br>
-            <b>4. Игровые посты тоже скроются?</b><br>
-            Нет, посты скрываются только для текущего раздела. В соседнем придётся игнорить заново, если понадобится.</p>
+                Сработает, но ник в меню запомнит не реальный, а тот, что был на маске.<br>
+                <b>2. Вконтакте работать будет?</b><br>
+                Нет, только на платформах типа mybb.<br>
+                <b>3. Юзер не узнает?</b><br>
+                Разве что расскажешь ему сам(а).<br>
+                <b>4. Игровые посты тоже скроются?</b><br>
+                Нет, посты скрываются только для текущего раздела. В соседнем придётся игнорить заново, если
+                понадобится.</p>
         </div>
     </div>
 </body>
+
+<script src="popup.js"></script>
+
 </html>

--- a/popup.html
+++ b/popup.html
@@ -80,7 +80,7 @@
         <h2>Дополнительные настройки:</h2>
         <form>
             <label class="hvHU_options__option" for="hide_instead">
-                <input type="checkbox" id="hide_instead"> Прятать посты юзера, а не вырезать их
+                <input type="checkbox" id="hide_instead"> Прятать посты юзеров, а не вырезать их
             </label>
         </form>
     </div>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,20 @@
+function save_options() {
+    var hideInsteadOfRemoving = document.getElementById('hide_instead').checked;
+
+    chrome.storage.sync.set(
+        { hvHU_hideInstead: hideInsteadOfRemoving },
+        function() {
+            console.log('hvHU__popup.js  => save_options(): SAVED');
+        }
+    );
+}
+
+function restore_options() {
+    chrome.storage.sync.get(['hvHU_hideInstead'], function(items) {
+        document.getElementById('hide_instead').checked =
+            items.hvHU_hideInstead;
+    });
+}
+
+document.addEventListener('DOMContentLoaded', restore_options);
+document.getElementById('hide_instead').addEventListener('click', save_options);

--- a/popup.js
+++ b/popup.js
@@ -4,7 +4,7 @@ function save_options() {
     chrome.storage.sync.set(
         { hvHU_hideInstead: hideInsteadOfRemoving },
         function() {
-            console.log('hvHU__popup.js  => save_options(): SAVED');
+            chrome.tabs.reload();
         }
     );
 }

--- a/style.css
+++ b/style.css
@@ -15,6 +15,4 @@
     padding: 8px 16px;
     margin: 8px 0;
     margin-left: auto;
-    border: 1px solid gray;
-    border-radius: 16px;
 }

--- a/style.css
+++ b/style.css
@@ -1,3 +1,20 @@
-#pun .topic .post.hvHiddenPost {
+#pun .topic .post.hvRemovedPost {
     display: none !important;
+}
+
+#pun .topic .post.hvHiddenPost .container {
+    display: none;
+}
+
+#pun .topic .post.hvHiddenPost.hvShow .container {
+    display: block;
+}
+
+#pun .topic .post.hvHiddenPost .hvHiddenSpoiler {
+    box-sizing: border-box;
+    padding: 8px 16px;
+    margin: 8px 0;
+    margin-left: auto;
+    border: 1px solid gray;
+    border-radius: 16px;
 }


### PR DESCRIPTION
Этот пулл-реквест:
- Добавляет в настройки расширения опцию "Прятать посты юзеров, а не вырезать их", чем резолвит #1;
  
  ![image](https://user-images.githubusercontent.com/22026957/77253798-e7896e00-6c6d-11ea-9d74-908f1ea81bee.png)
- Апдейтит версию до 1.1.0 (не знаю, насколько это уместно...) ✨ 

Я себе еще для этого репозитория настроила prettier, потому что я ленивая жопка, если где-то что-то переформатировалось совсем не так, как надо — скажи;